### PR TITLE
Implement user CRUD with hashed passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,19 @@ Este repositório serve como o backend de uma aplicação destinada à criação
 Ele deverá disponibilizar endpoints para que clientes possam definir novos formulários, consultar respostas e administrar os formulários já cadastrados.
 
 Embora a estrutura atual seja simples, este projeto é o ponto inicial para o desenvolvimento da API que irá persistir e manipular dados de formulários.
+
+## Gerenciamento de Usuários
+
+A aplicação fornece um conjunto de endpoints para cadastro, consulta, atualização e exclusão de usuários. As senhas são armazenadas de forma segura utilizando hash (bcrypt).
+
+### Instalação
+
+```bash
+pip install -r requirements.txt
+```
+
+### Execução
+
+```bash
+uvicorn app.main:app --reload
+```

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,10 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,78 @@
+from fastapi import Depends, FastAPI, HTTPException
+from sqlalchemy.orm import Session
+from passlib.context import CryptContext
+
+from . import models, schemas
+from .database import Base, SessionLocal, engine
+
+Base.metadata.create_all(bind=engine)
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+app = FastAPI(title="User Management API")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+@app.post("/users/", response_model=schemas.User)
+def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    db_user = db.query(models.User).filter(models.User.username == user.username).first()
+    if db_user:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    hashed_password = get_password_hash(user.password)
+    db_user = models.User(username=user.username, hashed_password=hashed_password)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@app.get("/users/", response_model=list[schemas.User])
+def read_users(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    users = db.query(models.User).offset(skip).limit(limit).all()
+    return users
+
+
+@app.get("/users/{user_id}", response_model=schemas.User)
+def read_user(user_id: int, db: Session = Depends(get_db)):
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@app.put("/users/{user_id}", response_model=schemas.User)
+def update_user(user_id: int, user: schemas.UserUpdate, db: Session = Depends(get_db)):
+    db_user = db.query(models.User).filter(models.User.id == user_id).first()
+    if db_user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    if user.username is not None:
+        db_user.username = user.username
+    if user.password is not None:
+        db_user.hashed_password = get_password_hash(user.password)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@app.delete("/users/{user_id}")
+def delete_user(user_id: int, db: Session = Depends(get_db)):
+    db_user = db.query(models.User).filter(models.User.id == user_id).first()
+    if db_user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    db.delete(db_user)
+    db.commit()
+    return {"detail": "User deleted"}

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+
+from .database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+class UserBase(BaseModel):
+    username: str
+
+class UserCreate(UserBase):
+    password: str
+
+class UserUpdate(BaseModel):
+    username: str | None = None
+    password: str | None = None
+
+class User(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+sqlalchemy
+passlib[bcrypt]


### PR DESCRIPTION
## Summary
- set up FastAPI project structure and dependencies
- implement SQLite models and Pydantic schemas
- create `/users` CRUD endpoints with password hashing
- document running the API

## Testing
- `python3 -m py_compile $(find app -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888dcb3b3d48327a8261ea4502f098a